### PR TITLE
Fix ops_arg_dat

### DIFF
--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -10,7 +10,7 @@ from devito.ir.iet.nodes import Call, Callable, Expression, IterationTree
 from devito.ir.iet.visitors import FindNodes
 from devito.ops.node_factory import OPSNodeFactory
 from devito.ops.types import Array, OpsAccessible, OpsDat, OpsStencil
-from devito.ops.utils import namespace, OpsDatDecl, OpsArgDecl
+from devito.ops.utils import namespace, OpsDatDecl
 from devito.symbolics import Add, Byref, ListInitializer, Literal
 from devito.tools import dtype_to_cstr
 from devito.types import Constant, DefaultDimension, Symbol

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -243,15 +243,15 @@ def create_ops_par_loop(trees, ops_kernel, parameters, block, name_to_ops_dat,
 
     ops_args = []
     for p in parameters:
-        ops_arg = create_ops_arg(p,
-                                 accessible_origin,
-                                 name_to_ops_dat,
-                                 par_to_ops_stencil)
+        if p.is_Constant:
+            ops_arg = create_ops_arg_gbl(p, accessible_origin,
+                                         name_to_ops_dat)
+        else:
+            ops_arg = create_ops_arg_dat(p, accessible_origin,
+                                         name_to_ops_dat,
+                                         par_to_ops_stencil)
 
-        ops_args.append(ops_arg.ops_type(ops_arg.ops_name,
-                                         ops_arg.elements_per_point,
-                                         ops_arg.dtype,
-                                         ops_arg.rw_flag))
+        ops_args.append(ops_arg)
 
     ops_par_loop_call = Call(
         namespace['ops_par_loop'], [
@@ -267,30 +267,34 @@ def create_ops_par_loop(trees, ops_kernel, parameters, block, name_to_ops_dat,
     return [range_array_init], ops_par_loop_call
 
 
-def create_ops_arg(p, accessible_origin, name_to_ops_dat, par_to_ops_stencil):
+def create_ops_arg_dat(p, accessible_origin, name_to_ops_dat, par_to_ops_stencil):
     elements_per_point = 1
     dtype = Literal('"%s"' % dtype_to_cstr(p.dtype))
 
-    if p.is_Constant:
-        ops_type = namespace['ops_arg_gbl']
-        ops_name = Byref(Constant(name=p.name[1:]))
-        rw_flag = namespace['ops_read']
+    accessible_info = accessible_origin[p.name]
+
+    if accessible_info.time is None:
+        ops_name = name_to_ops_dat[p.name]
     else:
-        ops_type = namespace['ops_arg_dat']
-        accessible_info = accessible_origin[p.name]
-        ops_name = name_to_ops_dat[p.name] \
-            if accessible_info.time is None \
-            else name_to_ops_dat[accessible_info.origin_name].\
+        ops_name = name_to_ops_dat[accessible_info.origin_name].\
             indexify([Add(accessible_info.time, accessible_info.shift)])
-        rw_flag = namespace['ops_read'] if p.read_only else namespace['ops_write']
 
-    ops_arg = OpsArgDecl(ops_type=ops_type,
-                         ops_name=ops_name,
-                         elements_per_point=elements_per_point,
-                         dtype=dtype,
-                         rw_flag=rw_flag)
+    rw_flag = namespace['ops_read'] if p.read_only else namespace['ops_write']
 
-    return ops_arg
+    return namespace['ops_arg_dat'](ops_name, elements_per_point,
+                                    par_to_ops_stencil[p], dtype, rw_flag)
+
+
+def create_ops_arg_gbl(p, accessible_origin, name_to_ops_dat):
+    elements_per_point = 1
+    dtype = Literal('"%s"' % dtype_to_cstr(p.dtype))
+
+    ops_name = Byref(Constant(name=p.name[1:]))
+    rw_flag = namespace['ops_read']
+
+    return namespace['ops_arg_gbl'](ops_name, elements_per_point,
+                                    dtype, rw_flag)
+
 
 
 def make_ops_ast(expr, nfops, is_write=False):

--- a/devito/ops/utils.py
+++ b/devito/ops/utils.py
@@ -17,7 +17,7 @@ OpsDatDecl = namedtuple(
 
 OpsArgDecl = namedtuple(
     'OpsArgDecl',
-    ['ops_type', 'ops_name', 'elements_per_point', 'dtype', 'rw_flag'])
+    ['ops_type', 'ops_name', 'elements_per_point', 'stencil', 'dtype', 'rw_flag'])
 
 # OPS API
 namespace['ops_init'] = 'ops_init'

--- a/devito/ops/utils.py
+++ b/devito/ops/utils.py
@@ -15,10 +15,6 @@ OpsDatDecl = namedtuple(
     'OpsDatDecl',
     ['dim_val', 'base_val', 'd_p_val', 'd_m_val', 'ops_decl_dat'])
 
-OpsArgDecl = namedtuple(
-    'OpsArgDecl',
-    ['ops_type', 'ops_name', 'elements_per_point', 'stencil', 'dtype', 'rw_flag'])
-
 # OPS API
 namespace['ops_init'] = 'ops_init'
 namespace['ops_partition'] = 'ops_partition'

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -15,10 +15,11 @@ pytestmark = skipif('noops', whole_module=True)
 from devito import Eq, Function, Grid, Operator, TimeFunction, configuration  # noqa
 from devito.ir.equations import ClusterizedEq  # noqa
 from devito.ops.node_factory import OPSNodeFactory  # noqa
-from devito.ops.transformer import create_ops_arg, create_ops_dat, make_ops_ast, to_ops_stencil  # noqa
+from devito.ops.transformer import (create_ops_arg_dat, create_ops_arg_gbl, # noqa
+                                    create_ops_dat, make_ops_ast, to_ops_stencil) # noqa
 from devito.ops.types import Array, OpsAccessible, OpsDat, OpsStencil, OpsBlock  # noqa
 from devito.ops.utils import namespace, AccessibleInfo, OpsDatDecl, OpsArgDecl  # noqa
-from devito.symbolics import Byref, ListInitializer, Literal, indexify  # noqa
+from devito.symbolics import Byref, ListInitializer, Literal, ccode, indexify  # noqa
 from devito.tools import dtype_to_cstr  # noqa
 from devito.types import Buffer, Constant, DefaultDimension, Symbol  # noqa
 
@@ -227,30 +228,23 @@ class TestOPSExpression(object):
     def test_create_ops_arg_constant(self):
         a = Constant(name='*a')
 
-        ops_arg = create_ops_arg(a, {}, {}, {})
+        ops_arg = create_ops_arg_gbl(a, {}, {})
 
-        assert ops_arg.ops_type == namespace['ops_arg_gbl']
-        assert str(ops_arg.ops_name) == str(Byref(Constant(name='a')))
-        assert ops_arg.elements_per_point == 1
-        assert ops_arg.dtype == Literal('"%s"' % dtype_to_cstr(a.dtype))
-        assert ops_arg.rw_flag == namespace['ops_read']
+        assert ccode(ops_arg) == 'ops_arg_gbl(&a, 1, "float", OPS_READ)'
 
-    @pytest.mark.parametrize('read', [True, False])
+    @pytest.mark.parametrize('read', ['True', 'False'])
     def test_create_ops_arg_function(self, read):
 
         u = OpsAccessible('u', dtype=np.float32, read_only=read)
         dat = OpsDat('u_dat')
         stencil = OpsStencil('stencil')
         info = AccessibleInfo(u, None, None, None)
+        read_flag = namespace['ops_read'] if read else namespace['ops_write']
 
-        ops_arg = create_ops_arg(u, {'u': info}, {'u': dat}, {u: stencil})
+        ops_arg = create_ops_arg_dat(u, {'u': info}, {'u': dat}, {u: stencil})
 
-        assert ops_arg.ops_type == namespace['ops_arg_dat']
-        assert ops_arg.ops_name == OpsDat('u_dat')
-        assert ops_arg.elements_per_point == 1
-        assert ops_arg.dtype == Literal('"%s"' % dtype_to_cstr(u.dtype))
-        assert ops_arg.rw_flag == \
-            namespace['ops_read'] if read else namespace['ops_write']
+        assert ccode(ops_arg) == 'ops_arg_dat(u_dat, 1, stencil, "float", %s)' \
+            % read_flag
 
     @pytest.mark.parametrize('equation, expected', [
         ('Eq(u.forward, u.dt2 + u.dxr - u.dyr - u.dyl)',

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -18,7 +18,7 @@ from devito.ops.node_factory import OPSNodeFactory  # noqa
 from devito.ops.transformer import (create_ops_arg_dat, create_ops_arg_gbl, # noqa
                                     create_ops_dat, make_ops_ast, to_ops_stencil) # noqa
 from devito.ops.types import Array, OpsAccessible, OpsDat, OpsStencil, OpsBlock  # noqa
-from devito.ops.utils import namespace, AccessibleInfo, OpsDatDecl, OpsArgDecl  # noqa
+from devito.ops.utils import namespace, AccessibleInfo, OpsDatDecl # noqa
 from devito.symbolics import Byref, ListInitializer, Literal, ccode, indexify  # noqa
 from devito.tools import dtype_to_cstr  # noqa
 from devito.types import Buffer, Constant, DefaultDimension, Symbol  # noqa


### PR DESCRIPTION
'ops_arg_dat' was not being declared with the stencil. While this works for the 'ops_arg_gbl', the 'ops_arg_dat' needs the stencil.

Fix:
Separated 'create_ops_dat' into two methods specific for each case.
Removed 'OpsArgDat' namedtuple. 
Fixed tests.