### PR TITLE
Fixed variable name bug

### DIFF
--- a/devito/ops/node_factory.py
+++ b/devito/ops/node_factory.py
@@ -37,7 +37,7 @@ class OPSNodeFactory(object):
 
         # Build the OPS arg identifier
         time_index = split_affine(indexed.indices[TimeFunction._time_position])
-        ops_arg_id = ('%s%s%s' % (indexed.name, time_index.var, time_index.shift)
+        ops_arg_id = ('%s%s%s' % (indexed.name, time_index.var, time_index.shift + indexed.function.time_order)
                       if indexed.function.is_TimeFunction else indexed.name)
 
         if ops_arg_id not in self.ops_args:
@@ -51,7 +51,7 @@ class OPSNodeFactory(object):
                 symbol_to_access,
                 time_index.var if indexed.function.is_TimeFunction else None,
                 time_index.shift if indexed.function.is_TimeFunction else None,
-                indexed.function.time_order if indexed.function.is_TimeFunction else None, 
+                indexed.function.time_order if indexed.function.is_TimeFunction else None,
                 indexed.function.name)
 
             self.ops_args[ops_arg_id] = accessible_info


### PR DESCRIPTION
Shift all time order variables so we don't have negative numbers in our variables name.