### PR TITLE
Fix CC and CXX environment variable for Cuda compilation.

### DIFF
--- a/devito/ops/compiler.py
+++ b/devito/ops/compiler.py
@@ -143,8 +143,8 @@ class CUDADeviceCompiler(CompilerOPS):
         self.include_dirs = include_dirs.split(' ')
 
     def __lookup_cmds__(self):
-        self.CC = os.environ.get('CC', 'nvcc')
-        self.CXX = os.environ.get('CXX', 'nvcc')
+        self.CC = 'nvcc'
+        self.CXX = 'nvcc'
 
 
 class CudaHostCompiler(CompilerOPS):


### PR DESCRIPTION
    There is no point in getting the value from CC environment variable if our code will only work if using nvcc.

This caused an error when using the code at NPAD. Because the variable CC and CXX were set to other value in those environment.